### PR TITLE
Migrating to mongoose 6.x

### DIFF
--- a/packages/api/src/app.js
+++ b/packages/api/src/app.js
@@ -13,7 +13,7 @@ import ShortLink from './models/short-link'
 
 // Connect to the MongoDB database
 const databaseURL = process.env.MONGODB_URI || 'mongodb://localhost/nazrin'
-mongoose.connect(databaseURL, { useNewUrlParser: true, useCreateIndex: true, useFindAndModify: false, useUnifiedTopology: true }).catch((err) => {
+mongoose.connect(databaseURL).catch((err) => {
   console.error(err)
 })
 


### PR DESCRIPTION
remove mongoose's connection options.
(useNewUrlParser, useCreateIndex, useUnifiedTopology are default true, and useFindAndModify is false)
ref: https://mongoosejs.com/docs/migrating_to_6.html#no-more-deprecation-warning-options