### PR TITLE
Revert "chore(deps): bump rotating-file-stream from 2.1.6 to 3.0.1"

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -25,7 +25,7 @@
     "morgan": "^1.10.0",
     "path": "^0.12.7",
     "raven": "^2.4.2",
-    "rotating-file-stream": "^3.0.1",
+    "rotating-file-stream": "^2.1.6",
     "validator": "^13.7.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12736,10 +12736,10 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rotating-file-stream@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/rotating-file-stream/-/rotating-file-stream-3.0.1.tgz#e9f8fe775e1d03ece21bf179a23d8629d1119ed8"
-  integrity sha512-f2JswqnOG1md26qdf5kDBmNBn6XOojm0z3GyjtjnykQhSOMg4DD+4DCstDvsHVx94vqd8vaKXB3KjT4vtP0iDQ==
+rotating-file-stream@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/rotating-file-stream/-/rotating-file-stream-2.1.6.tgz#c6400fa289aa2c61a5b4bf7e83a1eeb5542e5bb7"
+  integrity sha512-qS0ndAlDu80MMXeRonqGMXslF0FErzcUSbcXhus3asRG4cvCS79hc5f7s0x4bPAsH6wAwyHVIeARg69VUe3JmQ==
 
 rsvp@^4.8.4:
   version "4.8.4"


### PR DESCRIPTION
Reverts mayaeh/nazr.in#337

I think that rotating-file-stream v3.0 droped support Node.js v12.x
https://github.com/iccicci/rotating-file-stream/commit/22c30a4df656e7f5ae923d39dcc4d74a6b6291c1#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122